### PR TITLE
Fix iss 4

### DIFF
--- a/config.py
+++ b/config.py
@@ -35,8 +35,7 @@ if os.name == "nt":
             "help": "connect to serial port {}{}:".format(port, port_num),
         }
 
-here = Path(__file__).parent.absolute()
-
+here = Path(os.getcwd())
 files = (here / "snippets").glob("*.py")
 for file in files:
     try:


### PR DESCRIPTION
mpremote runs config.py in its own directory [source](https://github.com/micropython/micropython/blob/9e6885ad820a9f42bf93df56eb3f3be0c8639622/tools/mpremote/mpremote/main.py#L349) so this solution avoids the need for accessing the envar.